### PR TITLE
Update the README.md examples to show the new pretteir tracing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ hello world program output like this:
 
 ```console
 [TRACE origin::program] Program started
-[TRACE origin::thread] Main Thread[Pid(51383)] initialized
+[TRACE origin::thread] Main Thread[51383] initialized
 [TRACE origin::program] Calling `.init_array`-registered function `0x55e86306bb80(1, 0x7ffd0f76aad8, 0x7ffd0f76aae8)`
 [TRACE origin::program] Calling `origin_main(1, 0x7ffd0f76aad8, 0x7ffd0f76aae8)`
 Hello, world!

--- a/example-crates/eyra-optional-example/README.md
+++ b/example-crates/eyra-optional-example/README.md
@@ -10,7 +10,7 @@ shutdown:
 ```console
 $ RUST_LOG=trace cargo +nightly run --quiet --features=eyra,eyra/log,eyra/env_logger
 [TRACE origin::program] Program started
-[TRACE origin::thread] Main Thread[Pid(91601)] initialized
+[TRACE origin::thread] Main Thread[91601] initialized
 [TRACE origin::program] Calling `.init_array`-registered function `0x559006f43500(1, 0x7ffd7e5bacd8, 0x7ffd7e5bace8)`
 [TRACE origin::program] Calling `origin_main(1, 0x7ffd7e5bacd8, 0x7ffd7e5bace8)`
 Hello, world!


### PR DESCRIPTION
With sunfishcode/origin#61, thread tracing messages no longer print the redundant `Pid(` ... `)`.