### PR TITLE
Enable LTO support.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["/.github", "ci"]
 keywords = ["linux"]
 
 [dependencies]
-c-gull = { version = "0.15.2", default-features = false, features = ["eyra"] }
+c-gull = { version = "0.15.10", default-features = false, features = ["eyra"] }
 
 [dev-dependencies]
 assert_cmd = "2.0.12"

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ Known limitations in `Eyra` include:
  - Dynamic linking isn't implemented yet.
  - Many libc C functions that aren't typically needed by most Rust programs
    aren't implemented yet.
- - Enabling LTO doesn't work yet.
 
 ## Background
 

--- a/example-crates/hello-world-lto/.gitignore
+++ b/example-crates/hello-world-lto/.gitignore
@@ -1,0 +1,2 @@
+/target
+Cargo.lock

--- a/example-crates/hello-world-lto/Cargo.toml
+++ b/example-crates/hello-world-lto/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "hello-world-lto"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies]
+std = { package = "eyra", path = "../.." }
+
+# Enable LTO.
+[profile.release]
+lto = true
+
+# This is just an example crate, and not part of the c-ward workspace.
+[workspace]

--- a/example-crates/hello-world-lto/README.md
+++ b/example-crates/hello-world-lto/README.md
@@ -1,0 +1,5 @@
+This crate demonstrates the use of Eyra with LTO!
+
+This is the same as the [hello-world] example, but enables LTO.
+
+[hello-world]: https://github.com/sunfishcode/eyra/tree/main/example-crates/hello-world/

--- a/example-crates/hello-world-lto/build.rs
+++ b/example-crates/hello-world-lto/build.rs
@@ -1,0 +1,4 @@
+fn main() {
+    // Pass -nostartfiles to the linker.
+    println!("cargo:rustc-link-arg=-nostartfiles");
+}

--- a/example-crates/hello-world-lto/src/main.rs
+++ b/example-crates/hello-world-lto/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -60,6 +60,18 @@ fn example_crate_hello_world() {
 }
 
 #[test]
+fn example_crate_hello_world_lto() {
+    test_crate(
+        "hello-world",
+        &["--release"],
+        &[],
+        "Hello, world!\n",
+        "",
+        None,
+    );
+}
+
+#[test]
 fn example_crate_extern_crate_hello_world() {
     test_crate(
         "extern-crate-hello-world",


### PR DESCRIPTION
Update to c-gull 0.15.10, which fixes LTO compatibility. Add an example that uses LTO, and test it in the example-crates test.