### PR TITLE
Mention that Eyra currently requires a `*-gnu` target in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ fn main() {
 ```
 
 With that, `cargo build`, `cargo run`, `cargo test` (with Nightly) and so on
-with a `*-unknown-linux-gnu*` target work normally.
+will work normally with any `*-unknown-linux-gnu*` target.
 
 Under the covers, it's using [Origin] to start and stop the program, [c-ward]
 to handle libc calls from `std`, and [rustix] to do the printing, so it's

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ fn main() {
 ```
 
 With that, `cargo build`, `cargo run`, `cargo test` (with Nightly) and so on
-work normally. Under the covers, it's using [Origin] to start and stop the
-program, [c-ward] to handle libc calls from `std`, and [rustix] to do the
-printing, so it's completely implemented in Rust.
+with a `*-unknown-linux-gnu*` target work normally.
+
+Under the covers, it's using [Origin] to start and stop the program, [c-ward]
+to handle libc calls from `std`, and [rustix] to do the printing, so it's
+completely implemented in Rust.
 
 ## Examples
 


### PR DESCRIPTION
See #27.