### PR TITLE
Don't depend on libc inside a test

### DIFF
--- a/example-crates/no-std/src/main.rs
+++ b/example-crates/no-std/src/main.rs
@@ -1,10 +1,8 @@
 #![no_std]
 #![no_main]
-#![feature(rustc_private)]
 #![feature(lang_items)]
 #![allow(internal_features)]
 
-extern crate libc;
 extern crate eyra;
 
 #[no_mangle]


### PR DESCRIPTION
When the rustc-dev component is installed there will be two versions of
libc in the sysroot. This would result in an error as rustc doesn't know
which version to pick. In this case we don't actually depend on the libc
crate, so we can just remove the extern crate libc.