### PR TITLE
Rustup to "rustc 1.78.0-nightly (a84bb95a1 2024-02-13)"

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-12-19"
+channel = "nightly-2024-02-14"
 components = ["rustc", "cargo", "rust-std", "rust-src", "rustfmt"]

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -41,7 +41,7 @@ fn test_example(name: &str, features: &str, stdout: &str, stderr: &str) {
 
     let mut command = Command::new("cargo");
     if which::which("rustup").is_ok() {
-        command.arg("+nightly-2023-12-19");
+        command.arg("+nightly-2024-02-14");
     }
     command.arg("run").arg("--quiet");
     if !features.is_empty() {


### PR DESCRIPTION
The latest portable-simd version depends on a recent nightly, so if you don't have an old version in your lockfile, tests fail without this PR.