### PR TITLE
docs: `hello-world-small` example size update

### DIFF
--- a/example-crates/hello-world-small/README.md
+++ b/example-crates/hello-world-small/README.md
@@ -7,16 +7,16 @@ It uses the [workaround to support -Zbuild-std], and can be built with
 a command like this:
 
 ```console
-$ RUSTFLAGS="-Zlocation-detail=none -C relocation-model=static -Ctarget-feature=+crt-static" cargo +nightly run -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
+$ RUSTFLAGS="-Z location-detail=none -C relocation-model=static -Ctarget-feature=+crt-static" cargo +nightly run -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
 ```
 
 This applies all the techniques described on the [min-sized-rust] page
 before [Remove `core::fmt` with `no_main` and Careful Usage of `libstd`].
 
-As of this writing, this compiles to 37880 bytes. For comparison, using all
+As of this writing, this compiles to 24,616 bytes. For comparison, using all
 these same optimizations without Eyra, and using `x86_64-unknown-linux-musl`
 (which produces smaller statically-linked binaries than
-`x86_64-unknown-linux-gnu`), compiles to 50776 bytes.
+`x86_64-unknown-linux-gnu`), compiles to 30,288 bytes.
 
 If you're interested in going further down the `#![no_main]`/`#![no_std]`
 path, consider [using Origin directly] which can get down to 408 bytes. Or,


### PR DESCRIPTION
## Summary

- Rust nightly (1.83) now builds these targets (from a glibc host) at 13-20KB smaller.
- Delta reduced from the `~13KB` difference to a `6KB` difference.
- When built with LLD musl is additionally smaller by 5KB, roughly on par with eyra at ~300 bytes delta (_nightly fluctuations observed_).

---

## Reproduction

```console
# Docker with Fedora 41 for the base reproduction environment:
$ docker run --rm -it --workdir /example fedora:41

# Prep environment:
$ dnf install -y gcc rustup nano
$ rustup-init -y --profile minimal --default-toolchain nightly --target x86_64-unknown-linux-gnu x86_64-unknown-linux-musl --component rust-src
$ . "$HOME/.cargo/env"

# Create basic hello world example:
$ cargo init
# Add the release profile:
# https://github.com/sunfishcode/eyra/blob/v0.17.0/example-crates/hello-world-small/Cargo.toml#L10-L16
$ nano Cargo.toml
```

### musl (25KB)

```console
$ RUSTFLAGS="-Z location-detail=none -C relocation-model=static -C target-feature=+crt-static" cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-musl --release

$ du --bytes target/x86_64-unknown-linux-musl/release/example
30288   target/x86_64-unknown-linux-musl/release/example

# NOTE:
# 24,984 bytes with `-C link-arg=-fuse-ld=lld`
# 389,744 bytes with LLD and without `-Z build-std` args
```

### musl + zig (26.4KB)

```console
dnf install -y zig
cargo install cargo-zigbuild

# Only differs by replacing the `build` sub-command with `zigbuild`:
$ RUSTFLAGS="-Z location-detail=none -C relocation-model=static -C target-feature=+crt-static" cargo +nightly zigbuild -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-musl --release

$ du --bytes target/x86_64-unknown-linux-musl/release/example
26424   target/x86_64-unknown-linux-musl/release/example

# NOTE:
# Zig does not presently support static glibc builds, nor is it compatible with Eyra due to duplicate `_start` from Zig
# 351,728 bytes without `-Z build-std` args (Zig uses LLD by default).
```

### glibc (834KB)

```console
# glibc static libs are needed for gnu target to link statically:
$ dnf -y install glibc-static

# Same command as before, only adjusted `--target`
$ RUSTFLAGS="-Z location-detail=none -C relocation-model=static -C target-feature=+crt-static" cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release

$ du --bytes target/x86_64-unknown-linux-gnu/release/example
834224  target/x86_64-unknown-linux-gnu/release/example

# NOTE:
# No size difference when linking with LLD (slightly larger when linking with mold, as per usual)
# 1,121,168 bytes without `-Z build-std` args
```

### eyra (24.7KB)

```console
$ cargo add eyra --no-default-features
# `moreutils` provides the `sponge` command (or you could just edit via nano):
$ dnf -y install moreutils
# Add this line to the top of `src/main.rs`
$ echo 'extern crate eyra;' | cat - src/main.rs | sponge src/main.rs

# NOTE: Only differs by prepending `-C link-arg=nostartfiles`
$ RUSTFLAGS="-C link-arg=-nostartfiles -Z location-detail=none -C relocation-model=static -C target-feature=+crt-static" cargo +nightly build -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release

$ du --bytes target/x86_64-unknown-linux-gnu/release/example
24616   target/x86_64-unknown-linux-gnu/release/example

# NOTE:
# No size difference when linking with LLD.
# Increased to 24,696 bytes on nightly 2 days later.
# 388,384 bytes without `-Z build-std` args
```

## `nostd` reference

For an additional reference the [`nostd` example](https://github.com/sunfishcode/eyra/blob/v0.17.0/example-crates/no-std/src/main.rs) that was added at a later date:
- Presently **builds with eyra to `5,592` bytes** 😎 (_with the same `Cargo.toml` release profile used below_)
  - When built without the `-Z build-std` args increases to `10,144` bytes, or `7,608` bytes by adding `-C linker-plugin-lto -C linker=clang -C link-arg=-flto=full -C link-arg=-fuse-ld=mold` (_**note:** eyra fails to build if `-C link-arg=-fuse-ld=lld` is used with `-C linker-plugin-lto`_).
  - Nightly will be [required to build](https://github.com/sunfishcode/c-ward/issues/144) for a while.

- For the musl target (_without eyra_):
  - It builds to `13,464` bytes, but requires `-C link-arg=-lc` to build successfully. Adding `-C link-arg=-fuse-ld=lld` reduces this down to `3,776` bytes.
  - When built with Zig the size is `3,200` bytes,  or `2,928` bytes after stripping some ELF strings (_`-C link-arg=-lc` not required, Zig also defaults the linker to LLD already_):
     ```bash
     objcopy \
       --remove-section=.comment \
       --remove-section=.note.gnu.build-id \
       target/x86_64-unknown-linux-musl/release/example
     ```
- Static glibc gnu target (_without eyra_):
  - ~~also builds smaller at `4,760` bytes. This also requires `-C link-arg=-lc` to be successful.~~ (_Nevermind that segfaults and unexpectedly dynamic links glibc. Without `+crt-static` it'll build dynamically linked successfully at `4,440` bytes_)
  - This target requires `-C link-arg=/usr/lib64/libc.a -C link-arg=/usr/lib/gcc/x86_64-redhat-linux/14/libgcc_eh.a` (_at least on Fedora 41 with the `glibc-static` package_) to successfully build and weighs in at `692,976` bytes with the `-Z` build-std flags (_otherwise 64 bytes larger at `693,040` bytes_).
  - Possibly similar to the musl limitation, except the linker change barely decreases the size. Tried `-C linker-plugin-lto -C linker=clang -C link-arg=-flto=full` for cross-language LTO, but no improvement.