### PR TITLE
Add more code-size optimization flags.

### DIFF
--- a/example-crates/hello-world-small/README.md
+++ b/example-crates/hello-world-small/README.md
@@ -7,7 +7,7 @@ It uses the [workaround to support -Zbuild-std], and can be built with
 a command like this:
 
 ```console
-$ RUSTFLAGS="-Z location-detail=none -C relocation-model=static -Ctarget-feature=+crt-static" cargo +nightly run -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort --target x86_64-unknown-linux-gnu --release
+$ RUSTFLAGS="-Z location-detail=none -Zfmt-debug=none -C relocation-model=static -Ctarget-feature=+crt-static" cargo +nightly run -Z build-std=std,panic_abort -Z build-std-features=panic_immediate_abort,optimize_for_size --target x86_64-unknown-linux-gnu --release
 ```
 
 This applies all the techniques described on the [min-sized-rust] page

--- a/tests/example_crates.rs
+++ b/tests/example_crates.rs
@@ -76,11 +76,11 @@ fn example_crate_hello_world_small() {
         &[
             "--release",
             "-Zbuild-std=std,panic_abort",
-            "-Zbuild-std-features=panic_immediate_abort",
+            "-Zbuild-std-features=panic_immediate_abort,optimize_for_size",
         ],
         &[(
             "RUSTFLAGS",
-            "-Zlocation-detail=none -Crelocation-model=static -Ctarget-feature=+crt-static",
+            "-Zlocation-detail=none -Zfmt-debug=none -Crelocation-model=static -Ctarget-feature=+crt-static",
         )],
         "Hello, world!\n",
         "",


### PR DESCRIPTION
Add -Zfmt-debug=none and -Zbuild-std-features=optimize_for_size, which were recently added to [min-sized-rust].

[min-sized-rust]: https://github.com/johnthagen/min-sized-rust